### PR TITLE
Move Done into the proper state to fix done early bug

### DIFF
--- a/src/Ar/FIOWrap/CHANGELOG.md
+++ b/src/Ar/FIOWrap/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.10.1 - Fix done early bug
+
 0.10.0 - Add header parameter that if specified is added to the top on new files
 
 0.9.1 - Migrate from AsString to AsBrStr

--- a/src/Ar/FIOWrap/FIOWrapFn_Cyclic.st
+++ b/src/Ar/FIOWrap/FIOWrapFn_Cyclic.st
@@ -681,10 +681,7 @@ FUNCTION FIOWrapFn_Cyclic
 					
 					
 						(* otherwise, done, set status and go to wait state *)	
-					
-						t.OUT.STAT.Busy:=	0;
-						t.OUT.STAT.Done:=	1;
-						
+									
 						t.Internal.State:=	FIOWRAP_ST_INFO;
 					
 					END_IF (* If ErrorClose *)
@@ -760,6 +757,8 @@ FUNCTION FIOWrapFn_Cyclic
 				t.Internal.FUB.Info.enable:=	0;
 				IF(t.Internal.FUB.Info.status = FIOWRAP_STAT_OK)THEN	
 					t.Internal.FileLen := t.Internal.FileInfo.size;
+					t.OUT.STAT.Busy:=	0;
+					t.OUT.STAT.Done:=	1;
 					t.Internal.State:=	FIOWRAP_ST_WAIT;					
 				ELSE
 					(* Error *)		

--- a/src/Ar/FIOWrap/IEC.lby
+++ b/src/Ar/FIOWrap/IEC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?AutomationStudio FileVersion="4.9"?>
-<Library Version="0.10.0" SubType="IEC" xmlns="http://br-automation.co.at/AS/Library">
+<Library Version="0.10.1" SubType="IEC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File>CHANGELOG.md</File>
     <File Description="Exported data types">FIOWrap.typ</File>


### PR DESCRIPTION
## What:

The PR moves the Done bit set to the final state before going back to the wait state

## Why:

In the current location some usage will break because Done will be true for too long. This had a major impact on the CSVFileLib in AS 6

