### PR TITLE
Add missing P3 GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-export-publish.yml
+++ b/.github/workflows/build-export-publish.yml
@@ -1,0 +1,126 @@
+name: Build, Export, and Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. v1.0.0)'
+        required: true
+
+jobs:
+  build-export-publish:
+    runs-on: [AS6-runner]
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      PROJECT:     example/AsProject/AsProject.apj
+      PROJECT_DIR: example/AsProject
+      LIBRARY:     FIOWrap
+      LIBRARY_DIR: src/Ar/FIOWrap
+      EXPORT_DIR:  export
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@loupeteam'
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF_TYPE -eq 'tag') {
+            $ver = $env:GITHUB_REF_NAME -replace '^v', ''
+          } else {
+            $ver = "${{ inputs.version }}" -replace '^v', ''
+          }
+          if (-not $ver) {
+            Write-Error "Could not determine version. Push a v*.*.* tag or supply the version input."
+            exit 1
+          }
+          Write-Host "Publishing version: $ver"
+          "version=$ver" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_OUTPUT
+
+      - name: Find AS6 build executable
+        uses: loupeteam/br-actions/find-as6-build@v1
+        id: find-as
+
+      - name: Build Intel
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path: ${{ steps.find-as.outputs.exe-path }}
+          project:  ${{ env.PROJECT }}
+          config:   Intel
+
+      - name: Build ARM
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path: ${{ steps.find-as.outputs.exe-path }}
+          project:  ${{ env.PROJECT }}
+          config:   ARM
+
+      - name: Export library
+        uses: loupeteam/br-actions/export-as-library@v1
+        with:
+          project-dir: ${{ env.PROJECT_DIR }}
+          library:     ${{ env.LIBRARY }}
+          library-dir: ${{ env.LIBRARY_DIR }}
+          configs:     Intel ARM
+          output:      ${{ env.EXPORT_DIR }}
+          as-install:  ${{ steps.find-as.outputs.install-path }}
+
+      - name: Locate exported version directory
+        id: export-dir
+        shell: pwsh
+        run: |
+          $path = Get-ChildItem "$env:EXPORT_DIR/$env:LIBRARY" -Directory |
+                  Select-Object -First 1 -ExpandProperty FullName
+          if (-not $path) {
+            Write-Error "No exported version directory found under $env:EXPORT_DIR/$env:LIBRARY"
+            exit 1
+          }
+          Write-Host "Exported version directory: $path"
+          "path=$path" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_OUTPUT
+
+      - name: Generate package.json
+        uses: loupeteam/br-actions/prepare-lpm-package@v1
+        with:
+          library-dir: ${{ env.LIBRARY_DIR }}
+          output-dir:  ${{ steps.export-dir.outputs.path }}
+          version:     ${{ steps.version.outputs.version }}
+
+      - name: Publish to GitHub Packages
+        shell: pwsh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Write-Host "Publishing @loupeteam/$($env:LIBRARY.ToLower())@${{ steps.version.outputs.version }}"
+          Push-Location "${{ steps.export-dir.outputs.path }}"
+          npm publish
+          Pop-Location
+
+      - name: Upload exported library artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.LIBRARY }}-${{ steps.version.outputs.version }}
+          path: ${{ env.EXPORT_DIR }}/${{ env.LIBRARY }}/
+          if-no-files-found: error
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BuildDiagnostics
+          path: example/AsProject/Temp/BuildDiagnostics.log
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-mode:
+        description: 'Build mode'
+        required: false
+        default: 'Build'
+        type: choice
+        options:
+          - Build
+          - Rebuild
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+jobs:
+  build:
+    runs-on: [AS6-runner]
+
+    env:
+      PROJECT: example/AsProject/AsProject.apj
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Find AS6 build executable
+        uses: loupeteam/br-actions/find-as6-build@v1
+        id: find-as
+
+      - name: Build Intel
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path:   ${{ steps.find-as.outputs.exe-path }}
+          project:    ${{ env.PROJECT }}
+          config:     Intel
+          build-mode: ${{ inputs.build-mode || 'Build' }}
+
+      - name: Build ARM
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path:   ${{ steps.find-as.outputs.exe-path }}
+          project:    ${{ env.PROJECT }}
+          config:     ARM
+          build-mode: ${{ inputs.build-mode || 'Build' }}
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BuildDiagnostics
+          path: example/AsProject/Temp/BuildDiagnostics.log
+          if-no-files-found: ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      build-mode:
+      build_mode:
         description: 'Build mode'
         required: false
         default: 'Build'
@@ -38,7 +38,7 @@ jobs:
           exe-path:   ${{ steps.find-as.outputs.exe-path }}
           project:    ${{ env.PROJECT }}
           config:     Intel
-          build-mode: ${{ inputs.build-mode || 'Build' }}
+          build-mode: ${{ inputs.build_mode || 'Build' }}
 
       - name: Build ARM
         uses: loupeteam/br-actions/build-as-project@v1
@@ -46,7 +46,7 @@ jobs:
           exe-path:   ${{ steps.find-as.outputs.exe-path }}
           project:    ${{ env.PROJECT }}
           config:     ARM
-          build-mode: ${{ inputs.build-mode || 'Build' }}
+          build-mode: ${{ inputs.build_mode || 'Build' }}
 
       - name: Upload build diagnostics
         if: always()

--- a/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
+++ b/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
@@ -12,6 +12,39 @@
   <TaskClass Name="Cyclic#7" />
   <TaskClass Name="Cyclic#8" />
   <Libraries>
+    <LibraryObject Name="ArEventLog" Source="Libraries._AS.ArEventLog.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsARCfg" Source="Libraries._AS.AsARCfg.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsArProf" Source="Libraries._AS.AsArProf.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrMath" Source="Libraries._AS.AsBrMath.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrStr" Source="Libraries._AS.AsBrStr.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrWStr" Source="Libraries._AS.AsBrWStr.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsEPL" Source="Libraries._AS.AsEPL.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsGuard" Source="Libraries._AS.AsGuard.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsHttp" Source="Libraries._AS.AsHttp.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIO" Source="Libraries._AS.AsIO.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIOAcc" Source="Libraries._AS.AsIOAcc.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIODiag" Source="Libraries._AS.AsIODiag.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIOTime" Source="Libraries._AS.AsIOTime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsMem" Source="Libraries._AS.AsMem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsSem" Source="Libraries._AS.AsSem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsTCP" Source="Libraries._AS.AsTCP.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsUDP" Source="Libraries._AS.AsUDP.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsUSB" Source="Libraries._AS.AsUSB.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsXml" Source="Libraries._AS.AsXml.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsZip" Source="Libraries._AS.AsZip.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="astime" Source="Libraries._AS.astime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="brsystem" Source="Libraries._AS.brsystem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="DataObj" Source="Libraries._AS.DataObj.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="dvframe" Source="Libraries._AS.dvframe.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="FileIO" Source="Libraries._AS.FileIO.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="LoopConR" Source="Libraries._AS.LoopConR.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTBasics" Source="Libraries._AS.MTBasics.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTLookUp" Source="Libraries._AS.MTLookUp.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTTypes" Source="Libraries._AS.MTTypes.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="operator" Source="Libraries._AS.operator.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="runtime" Source="Libraries._AS.runtime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="standard" Source="Libraries._AS.standard.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="sys_lib" Source="Libraries._AS.sys_lib.lby" Memory="UserROM" Language="binary" Debugging="true" />
     <LibraryObject Name="stringext" Source="Libraries.Loupe.stringext.lby" Memory="UserROM" Language="Binary" Debugging="true" />
     <LibraryObject Name="FIOWrap" Source="Libraries.Loupe.FIOWrap.lby" Memory="UserROM" Language="IEC" Debugging="true" />
   </Libraries>


### PR DESCRIPTION
## What
Adds the two GitHub Actions workflows that were missed in the original AS6 migration:
- `build.yml` — PR build validation (Intel + ARM)
- `build-export-publish.yml` — tag-driven library publish to GitHub Packages

## Why
PR #6 (the AS6 migration) only included P1+P2 (example project + library version bump). The `.github/workflows/` directory was never added. As a result, the `v1.0.0` git tag was pushed but never triggered any publish workflow, and `@loupeteam/fiowrap@1.0.0` was never published to GitHub Packages.

## After merge
1. Trigger publish via `workflow_dispatch` with version input `v1.0.0` to publish from `main` (which has the same source as the `v1.0.0` tag — only the workflow files differ).

## Notes
- Uses static `LIBRARY: FIOWrap` env var (matching the SerComm/StringExt pattern, not the broken LogThat dynamic-derivation pattern that was fixed in LogThat#5).
- Both workflows are byte-identical to SerComm's with the library name substituted.